### PR TITLE
inxi.1: fix links

### DIFF
--- a/inxi.1
+++ b/inxi.1
@@ -534,7 +534,7 @@ Next, if you don't already have it, you need to install shell.py,
 which is a python script. 
 
 In a web browser, Click on the download button at:
-.I http://www.weechat.org/scripts/source/stable/shell.py.html/
+.I https://www.weechat.org/scripts/source/stable/shell.py.html/
 
 Make the script executable by
 
@@ -561,7 +561,7 @@ inxi will read the following configuration/initialization files in the following
 .TP
 See wiki pages for more information on how to set these up:
 .TP 
-.I http://code.google.com/p/inxi/wiki/script_configuration_files 
+.I http://smxi.org/docs/inxi-configuration.htm
 .SH BUGS 
 Please report bugs using the following resources. 
 


### PR DESCRIPTION
* weechat.org has HSTS so using https is encouraged.
* code.google.com says that the project is read-only and inxi has moved
  to GitHub so linking to what seems to be the current version of
  documentation would be better.