### PR TITLE
Fix some slightly broken man-page markup.

### DIFF
--- a/inxi.1
+++ b/inxi.1
@@ -115,8 +115,8 @@ Setting a specific color type removes the global color selection.
 .TP
 .B \-C\fR,\fB \-\-cpu\fR
 Show full CPU output, including per CPU clock speed and CPU max speed (if available).
-If max speed data present, shows \fB(max)\fR in short output formats (\fB\inxi\fR,
-\fB\inxi \-b\fR) if actual CPU speed matches max CPU speed. If max CPU speed does
+If max speed data present, shows \fB(max)\fR in short output formats (\fBinxi\fR,
+\fBinxi \-b\fR) if actual CPU speed matches max CPU speed. If max CPU speed does
 not match actual CPU speed, shows both actual and max speed information.
 See \fB\-x\fR for more options.
 


### PR DESCRIPTION
Those \i escapes are incorrect. My doclifter program tripped over them.