### PR TITLE
E2K: fixed getting bitness for MCST Elbrus CPU when using "-f" option

### DIFF
--- a/inxi
+++ b/inxi
@@ -435,7 +435,7 @@ sub set_os {
 	if ($cpu_arch =~ /(armv[1-7]|32|sparc_v9)/){
 		$bits_sys = 32;
 	}
-	elsif ($cpu_arch =~ /(alpha|64)/){
+	elsif ($cpu_arch =~ /(alpha|64|e2k)/){
 		$bits_sys = 64;
 	}
 	if ( $os =~ /(aix|bsd|cosix|dragonfly|darwin|hp-?ux|indiana|irix|sunos|solaris|ultrix|unix)/ ){


### PR DESCRIPTION
Before editing:
CPU:       Topology: 8-Core model: E8C bits: N/A type: MCP L2 cache: N/A
           Speed: 1300 MHz min/max: N/A Core speeds (MHz): 1: 1300 2: 1300 3: 1300 4: 1300 5: 1300 6: 1300 7: 1300 8: 1300
           Flags: N/A

After editing:
CPU:       Topology: 8-Core model: E8C bits: 64 type: MCP L2 cache: N/A
           Speed: 1300 MHz min/max: N/A Core speeds (MHz): 1: 1300 2: 1300 3: 1300 4: 1300 5: 1300 6: 1300 7: 1300 8: 1300
           Flags: N/A

About this processor:
- https://en.wikipedia.org/wiki/Elbrus-8S