### PR TITLE
Add support for Picom compositor

### DIFF
--- a/inxi
+++ b/inxi
@@ -3354,6 +3354,7 @@ sub program_values {
 	'papyros' => ['^papyros',0,'0','papyros',0,1,0],
 	'pekwm' => ['^pekwm',3,'--version','PekWM',0,1,0],
 	'perceptia' => ['^perceptia',0,'0','perceptia',0,1,0],
+	'picom' => ['^\d',1,'--version','Picom',0,1,0],
 	'plasmashell' => ['^plasmashell',2,'--version','KDE Plasma',0,1,0],
 	'qtdiag' => ['^qt',2,'--version','Qt',0,1,0],
 	'qtile' => ['^qtile',0,'0','Qtile',0,0,1],
@@ -9897,6 +9898,7 @@ sub display_compositor {
 		['orbital','orbital','','orbital'],
 		['papyros','papyros','','papyros'],
 		['perceptia','perceptia','','perceptia'],
+		['picom','picom','','picom'],
 		['rustland','rustland','','rustland'],
 		['sommelier','sommelier','','sommelier'],
 		['sway','sway','','sway'],
@@ -19116,7 +19118,7 @@ sub set_ps_gui {
 		@temp=qw(3dwm asc budgie-wm compiz compton deepin-wm dwc dcompmgr 
 		enlightenment fireplace gnome-shell grefson kmscon kwin_wayland kwin_x11
 		liri marco metisse mir moblin motorcar muffin mutter
-		orbital papyros perceptia rustland sommelier sway swc
+		orbital papyros perceptia picom rustland sommelier sway swc
 		ukwm unagi unity-system-compositor
 		wavy waycooler way-cooler wayhouse westford weston xcompmgr);
 		@match = (@match,@temp);


### PR DESCRIPTION
This PR allows `inxi` to detect `picom` compositor. 

Picom is a fork of Compton. As of 2018, this is the only actively maintained fork, although it only officially changed names from 'compton' to 'picom' in 2019 ([[1]](https://github.com/yshui/picom/issues/222), [[2]](https://github.com/yshui/picom/issues/228)). 

This PR adds support for detecting the compositor under the new name. I have added support somewhat naively, by copying and renaming references to `compton`. This should work (and indeed appears to, `inxi -Gxx` now detects `picom` as compositor), but let me know if I've missed anything. 

Just in case, I'm adding the answers to the questions listed in https://github.com/smxi/inxi/issues/158

> A: does compositor program name support --version. If not, does it use an alternate version option, if so, what, like: -v -V -version.

Yes, `--version`.

> B: If it supports --version, does it output to stdout or stderr when in the running environment? Use program --version 2>/dev/null to confirm that it goes to stdout, if the result is empty, it is going to stderr if program --version showed output.

stdout

> C: what is the actual program name when it is running

`picom`

> D: can it be detected in xprop -root? I assume not since most compositors are wayland

No

> E: is the program name different from the actual application name (yes, this happens, sadly).

No

> F: if --version exists, what is the complete output of that command, so that the patterns for detection can be added

`v7.5` currently

> G: does the compositor also act as a window manager? if so, it must then be added to the various window manager detection blocks as well.

No