### PR TITLE
Adding snapcraft.yaml to be able to pack inxi as snap for possible distribution over snapstore

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,49 @@
+name: inxi
+version: 3.3.04-1
+summary: inxi - a command line system information tool
+description: |
+  inxi is a full featured CLI system information tool.
+  It is available in most Linux distribution repositories,
+  and does its best to support the BSDs.
+confinement: devmode
+base: core18
+grade: stable
+
+parts:
+  inxi:
+    plugin: dump
+    source: https://github.com/smxi/inxi/archive/$SNAPCRAFT_PROJECT_VERSION.tar.gz
+    stage-packages:
+      - pciutils
+      - procps
+      - libxml-dumper-perl
+      - libcpanel-json-xs-perl
+      - libjson-xs-perl
+      - wget
+      - dmidecode
+      - file
+      - dnsutils
+      - hddtemp
+      - iproute2
+      - sudo
+      - kmod
+      - lm-sensors
+      - mesa-utils
+      - tree
+      - usbutils
+      - x11-utils
+      - x11-xserver-utils
+      - libatm1
+      - libmagic-dev
+      - perl-base
+      - libfile-find-rule-perl-perl
+      - locales-all
+
+apps:
+  inxi:
+    environment:
+      LOCPATH: "$SNAP/usr/lib/locale"
+      PERL5LIB:  "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl-base/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl5/5.26/:$SNAP/usr/share/perl5/:$SNAP/usr/share/perl/5.26.1/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl/5.26/:$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/perl/5.26.1/"
+      HOME: "$SNAP_USER_COMMON"
+    command: perl $SNAP/inxi
+


### PR DESCRIPTION
Hello smxi,

thank you for this great project. I am working on the packaging of inxi as a snap and I wanted to know what your thoughts are about this.

I added a snapcraft.yaml which can be used to build inxi as a snap package (Instructions [here]( https://snapcraft.io/docs/pre-built-apps))

Basically the inxi version is pulled from github and packed as a snap. An option would be to automate this process with every new released version.

What do you think about this way of distribution? I think it would make it easier to bring the newest version to users.

Regards,
wirthual

